### PR TITLE
Add uv setup and GUI mode instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 __pycache__/
+
+.venv/

--- a/README.md
+++ b/README.md
@@ -8,12 +8,38 @@ where each bot has 10 HP and deals 1 damage per attack.
 
 Run the arena with:
 
-```
+```bash
 python arena.py
 ```
 
 You can also specify a different bot directory:
 
-```
+```bash
 python arena.py path/to/bots
 ```
+
+## GUI mode
+
+If `tkinter` is available on your system you can run the arena with a
+simple GUI by passing `--gui`:
+
+```bash
+python arena.py --gui
+```
+
+The flag can be combined with a custom bot directory as well.
+
+## Environment management with uv
+
+The project includes a `pyproject.toml` and `uv.lock` so that the
+environment can be managed with [uv](https://github.com/astral-sh/uv).
+Install uv (e.g. `pip install uv`) and then create the virtual
+environment and install dependencies:
+
+```bash
+uv venv
+uv sync
+```
+
+After this the arena can be run with `uv run python arena.py` or by
+running `python arena.py` within the created `.venv`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "python-rts"
+version = "0.1.0"
+description = "Simple RTS bot arena"
+authors = [{name="Unknown"}]
+readme = "README.md"
+dependencies = []
+requires-python = ">=3.10"
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 2
+requires-python = ">=3.10"
+
+[[package]]
+name = "python-rts"
+version = "0.1.0"
+source = { editable = "." }


### PR DESCRIPTION
## Summary
- document GUI mode and uv usage in README
- create `pyproject.toml` and `uv.lock` for uv-managed environment
- ignore local virtual environment

## Testing
- `python -m py_compile arena.py bots/*.py`

------
https://chatgpt.com/codex/tasks/task_e_683fc295f5248320b7d72f30c06f584e