### PR TITLE
Add FastAPI server with Vite client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__/
 
 .venv/
+
+frontend/node_modules/

--- a/README.md
+++ b/README.md
@@ -72,3 +72,27 @@ uv sync
 
 After this the arena can be run with `uv run python arena.py` or by
 running `python arena.py` within the created `.venv`.
+
+## Web server and frontend
+
+To watch battles in the browser start the FastAPI server:
+
+```bash
+uvicorn server:app --reload
+```
+
+The server keeps the game running indefinitely. New bots can be added
+by POSTing to `/bots/{bot_name}` where `bot_name` is a Python file in
+the `bots/` directory without the extension. The current board state is
+available at `/state`.
+
+The `frontend/` folder contains a minimal [Vite](https://vitejs.dev)
+setup. Start it with:
+
+```bash
+npm install
+npm run dev --prefix frontend
+```
+
+This opens a page that polls the server every second and renders the
+board on screen.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Python RTS Arena</title>
+  </head>
+  <body>
+    <h1>Python RTS Arena</h1>
+    <div id="board"></div>
+    <script type="module" src="/main.js"></script>
+  </body>
+</html>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,0 +1,33 @@
+const boardEl = document.getElementById('board');
+const boardSize = 5; // same as server
+
+function render(state) {
+  boardEl.innerHTML = '';
+  boardEl.style.display = 'grid';
+  boardEl.style.gridTemplateColumns = `repeat(${boardSize}, 40px)`;
+  boardEl.style.gridTemplateRows = `repeat(${boardSize}, 40px)`;
+  for (let y = 0; y < boardSize; y++) {
+    for (let x = 0; x < boardSize; x++) {
+      const cell = document.createElement('div');
+      cell.style.width = '40px';
+      cell.style.height = '40px';
+      cell.style.border = '1px solid #ccc';
+      const bot = Object.entries(state).find(([, info]) => info.pos[0] === x && info.pos[1] === y);
+      if (bot) {
+        cell.textContent = bot[0][0];
+        cell.style.background = '#faa';
+        cell.title = bot[0] + ' HP: ' + bot[1].hp;
+      }
+      boardEl.appendChild(cell);
+    }
+  }
+}
+
+async function fetchState() {
+  const res = await fetch('http://localhost:8000/state');
+  const data = await res.json();
+  render(data);
+}
+
+setInterval(fetchState, 1000);
+fetchState();

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "python-rts-frontend",
+  "type": "module",
+  "scripts": {
+    "dev": "vite"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  server: {
+    open: true,
+  },
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,10 @@ version = "0.1.0"
 description = "Simple RTS bot arena"
 authors = [{name="Unknown"}]
 readme = "README.md"
-dependencies = []
+dependencies = [
+    "fastapi",
+    "uvicorn[standard]"
+]
 requires-python = ">=3.10"
 
 [build-system]

--- a/server.py
+++ b/server.py
@@ -1,0 +1,106 @@
+"""Simple HTTP server for the Python RTS arena using FastAPI.
+
+This server keeps the game running indefinitely. Clients can query the
+current game state and add bots at runtime.
+"""
+
+import asyncio
+import importlib.util
+from pathlib import Path
+from typing import Dict, Optional
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+
+from arena import Game, load_bots
+
+
+class PersistentGame(Game):
+    """Game that can run indefinitely one step at a time."""
+
+    def step(self) -> None:
+        """Run a single turn for all alive bots."""
+        if sum(info['hp'] > 0 for info in self.bots.values()) <= 1:
+            # Nothing to do if only one bot (or none) is alive
+            return
+        for name, info in list(self.bots.items()):
+            if info['hp'] <= 0:
+                continue
+            state = {
+                'self_hp': info['hp'],
+                'self_pos': self.positions[name],
+                'board_size': self.board_size,
+                'enemies': {
+                    n: {'hp': i['hp'], 'pos': self.positions[n]}
+                    for n, i in self.bots.items()
+                    if n != name and i['hp'] > 0
+                },
+            }
+            if not state['enemies']:
+                continue
+            try:
+                action = info['bot'].act(state)
+            except Exception:
+                continue
+            self._handle_action(name, action)
+
+    def get_state(self) -> Dict[str, Dict[str, int]]:
+        """Return a JSON serialisable state."""
+        return {
+            name: {
+                'hp': info['hp'],
+                'pos': self.positions[name],
+            }
+            for name, info in self.bots.items()
+        }
+
+
+game: Optional[PersistentGame] = None
+
+app = FastAPI()
+app.add_middleware(CORSMiddleware, allow_origins=['*'])
+
+
+@app.on_event('startup')
+async def startup():
+    global game
+    bots = load_bots('bots')
+    game = PersistentGame(bots)
+    asyncio.create_task(game_loop())
+
+
+async def game_loop():
+    while True:
+        await asyncio.sleep(1)
+        game.step()
+
+
+@app.get('/state')
+async def state():
+    return game.get_state()
+
+
+@app.post('/bots/{bot_file}')
+async def add_bot(bot_file: str):
+    """Add a new bot by filename from the bots directory."""
+    file_path = Path('bots') / f'{bot_file}.py'
+    if not file_path.exists():
+        raise HTTPException(status_code=404, detail='Bot not found')
+    spec = importlib.util.spec_from_file_location(bot_file, file_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    if not hasattr(module, 'Bot'):
+        raise HTTPException(status_code=400, detail='No Bot class in file')
+    bot = module.Bot()
+    if not hasattr(bot, 'name'):
+        bot.name = bot_file
+    game.bots[bot.name] = {'bot': bot, 'hp': 10}
+    # Place at random position avoiding collisions
+    existing = set(game.positions.values())
+    for x in range(game.board_size):
+        for y in range(game.board_size):
+            if (x, y) not in existing:
+                game.positions[bot.name] = (x, y)
+                return {'status': 'ok'}
+    raise HTTPException(status_code=400, detail='Board full')
+

--- a/uv.lock
+++ b/uv.lock
@@ -6,3 +6,11 @@ requires-python = ">=3.10"
 name = "python-rts"
 version = "0.1.0"
 source = { editable = "." }
+
+[[package]]
+name = "fastapi"
+version = "0.97.0"
+
+[[package]]
+name = "uvicorn"
+version = "0.27.0.post1"


### PR DESCRIPTION
## Summary
- implement `server.py` using FastAPI to run an endless game loop
- support adding bots at runtime and retrieving current state
- add minimal Vite frontend under `frontend/` to display the board
- document web usage in README
- add FastAPI and uvicorn dependencies
- ignore `frontend/node_modules`

## Testing
- `python -m py_compile arena.py server.py bots/*.py`
- `python -m uvicorn --version`


------
https://chatgpt.com/codex/tasks/task_e_683fd23ab4088320be3970a9c7086228