### PR TITLE
Improve README setup and add tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test
+
+test:
+	python -m pytest -v

--- a/README.md
+++ b/README.md
@@ -7,6 +7,20 @@ method. The provided `arena.py` script loads all bots from the folder
 and runs a battle where each bot has 10 HP and can move or shoot at
 enemies within range.
 
+## Setup
+
+First create a Python virtual environment using
+[uv](https://github.com/astral-sh/uv). Install `uv` if you don't have it
+already (`pip install uv`) and then run:
+
+```bash
+uv venv
+uv sync
+```
+
+After this the arena can be run with `uv run python arena.py` or by
+running `python arena.py` within the created `.venv`.
+
 Run the arena with:
 
 ```bash
@@ -60,18 +74,14 @@ If anything else is returned, the bot simply skips its turn.
 
 ## Environment management with uv
 
-The project includes a `pyproject.toml` and `uv.lock` so that the
-environment can be managed with [uv](https://github.com/astral-sh/uv).
-Install uv (e.g. `pip install uv`) and then create the virtual
-environment and install dependencies:
+The repository is configured to work with
+[uv](https://github.com/astral-sh/uv). Once you have created the virtual
+environment as shown above you can run commands inside it using
+`uv run`:
 
 ```bash
-uv venv
-uv sync
+uv run python arena.py
 ```
-
-After this the arena can be run with `uv run python arena.py` or by
-running `python arena.py` within the created `.venv`.
 
 ## Web arena
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,6 @@ requires-python = ">=3.10"
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+py-modules = ["arena", "webarena"]

--- a/tests/test_readme_commands.py
+++ b/tests/test_readme_commands.py
@@ -1,0 +1,86 @@
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+README = Path(__file__).resolve().parents[1] / "README.md"
+
+
+def extract_commands():
+    commands = []
+    in_block = False
+    current = ""
+    for line in README.read_text().splitlines():
+        if line.startswith("```bash"):
+            in_block = True
+            continue
+        if in_block:
+            if line.startswith("```"):
+                if current:
+                    commands.append(current.strip())
+                    current = ""
+                in_block = False
+                continue
+            line = line.rstrip()
+            if line.endswith("\\"):
+                current += line[:-1] + " "
+            else:
+                current += line
+                commands.append(current.strip())
+                current = ""
+    return commands
+
+
+def run(cmd, cwd=None, timeout=30):
+    proc = subprocess.Popen(cmd, shell=True, cwd=cwd)
+    try:
+        proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.terminate()
+        try:
+            proc.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.communicate()
+    return proc.returncode == 0
+
+
+def test_readme_commands():
+    commands = extract_commands()
+    for cmd in commands:
+        if "path/to/bots" in cmd:
+            cmd = cmd.replace("path/to/bots", "bots")
+
+        if cmd.startswith("curl"):
+            server = subprocess.Popen(
+                "uvicorn webarena:app --reload", shell=True
+            )
+            time.sleep(2)
+            try:
+                assert run(cmd, timeout=5)
+            finally:
+                server.terminate()
+                server.wait(timeout=5)
+            continue
+
+        if cmd.startswith("uvicorn webarena:app --reload"):
+            proc = subprocess.Popen(cmd, shell=True)
+            time.sleep(2)
+            proc.terminate()
+            proc.wait(timeout=5)
+            continue
+
+        if cmd.startswith("npm install"):
+            assert run(cmd, cwd="frontend", timeout=120)
+            continue
+
+        if cmd.startswith("npm run dev"):
+            proc = subprocess.Popen(cmd, shell=True, cwd="frontend")
+            time.sleep(2)
+            proc.terminate()
+            proc.wait(timeout=5)
+            continue
+
+        assert run(cmd)
+


### PR DESCRIPTION
## Summary
- explain how to create the virtual environment first in README
- adjust environment section to reference `uv run`
- let setuptools know the module layout for uv
- add test that executes README commands
- provide `make test` helper

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683fd73874e4832082a8cbb9fff2e66a