### PR TITLE
Add Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY pyproject.toml ./
+RUN pip install --no-cache-dir fastapi uvicorn
+COPY . .
+CMD ["python", "arena.py"]

--- a/README.md
+++ b/README.md
@@ -1,54 +1,34 @@
 # Python RTS Bot Arena
 
-This repository contains a simple arena for running Python bots against
-one another on a small grid. Place your bot files in the `bots/`
-directory. Each bot must define a `Bot` class with an `act(state)`
-method. The provided `arena.py` script loads all bots from the folder
-and runs a battle where each bot has 10 HP and can move or shoot at
-enemies within range.
+This repository contains a simple arena for running Python bots against one another on a small grid. Place your bot files in the `bots/` directory. Each bot must define a `Bot` class with an `act(state)` method. The provided scripts allow running matches in the terminal or via a small web server.
 
-## Setup
+## Running with Docker
 
-First create a Python virtual environment using
-[uv](https://github.com/astral-sh/uv). Install `uv` if you don't have it
-already (`pip install uv`) and then run:
+The recommended way to try the arena is using Docker Compose. Make sure you have Docker and Docker Compose installed then build the image:
 
 ```bash
-uv venv
-uv sync
+docker compose build
 ```
 
-After this the arena can be run with `uv run python arena.py` or by
-running `python arena.py` within the created `.venv`.
-
-Run the arena with:
+Start the web arena server:
 
 ```bash
-python arena.py
+docker compose up
 ```
 
-You can also specify a different bot directory:
+The API will be available on `http://localhost:8000`.
+
+You can also run a single match in the terminal:
 
 ```bash
-python arena.py path/to/bots
+docker compose run --rm app python arena.py
 ```
 
-## GUI mode
-
-If `tkinter` is available on your system you can run the arena with a
-simple GUI by passing `--gui`:
-
-```bash
-python arena.py --gui
-```
-
-The flag can be combined with a custom bot directory as well.
+Bots placed inside the `bots/` directory on the host are mounted into the container automatically.
 
 ## Writing your own bots
 
-Place a Python file in the `bots/` directory defining a class `Bot` with
-an `act(state)` method. The `state` dictionary passed to `act` contains
-your current HP and position as well as information about the enemies:
+Place a Python file in the `bots/` directory defining a class `Bot` with an `act(state)` method. The `state` dictionary passed to `act` contains your current HP and position as well as information about the enemies:
 
 ```
 state = {
@@ -64,48 +44,24 @@ state = {
 
 Return a tuple to describe your action:
 
-- `('move', direction)` moves one tile in the given direction (`up`,
-  `down`, `left` or `right`). A move that would leave the board or bump
-  into another bot is ignored.
-- `('attack', enemy_name)` shoots at the given enemy if it is within a
-  Manhattan distance of 3 tiles.
+- `('move', direction)` moves one tile in the given direction (`up`, `down`, `left` or `right`). A move that would leave the board or bump into another bot is ignored.
+- `('attack', enemy_name)` shoots at the given enemy if it is within a Manhattan distance of 3 tiles.
 
 If anything else is returned, the bot simply skips its turn.
 
-## Environment management with uv
-
-The repository is configured to work with
-[uv](https://github.com/astral-sh/uv). Once you have created the virtual
-environment as shown above you can run commands inside it using
-`uv run`:
-
-```bash
-uv run python arena.py
-```
-
 ## Web arena
 
-A simple web server is provided in `webarena.py` using FastAPI. It runs an
-endless game loop where new bots can be added via an HTTP request and the
-state is broadcast over a WebSocket.
-
-Start the server:
-
-```bash
-uvicorn webarena:app --reload
-```
+A simple FastAPI server lives in `webarena.py`. It runs an endless game loop where new bots can be added via an HTTP request and the state is broadcast over a WebSocket. When started through Docker Compose, it is already running.
 
 Add a bot (specify the module name without `.py`):
 
 ```bash
-curl -X POST -H "Content-Type: application/json" \
-  -d '{"bot": "random_bot"}' http://localhost:8000/add_bot
+curl -X POST -H "Content-Type: application/json" -d '{"bot": "random_bot"}' http://localhost:8000/add_bot
 ```
 
 Connect to `ws://localhost:8000/ws` to receive game updates every second.
 
-A basic front‑end built with Vite lives in the `frontend` directory. After
-installing Node.js dependencies run:
+A basic front‑end built with Vite lives in the `frontend` directory. After installing Node.js dependencies run:
 
 ```bash
 npm install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.9'
+services:
+  app:
+    build: .
+    volumes:
+      - ./bots:/app/bots
+    ports:
+      - "8000:8000"
+    command: uvicorn webarena:app --host 0.0.0.0 --reload

--- a/tests/test_readme_commands.py
+++ b/tests/test_readme_commands.py
@@ -2,6 +2,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+import shutil
 
 
 README = Path(__file__).resolve().parents[1] / "README.md"
@@ -51,6 +52,13 @@ def test_readme_commands():
     for cmd in commands:
         if "path/to/bots" in cmd:
             cmd = cmd.replace("path/to/bots", "bots")
+
+        if cmd.startswith("docker ") or cmd.startswith("docker-compose"):
+            if shutil.which("docker") is None:
+                # Skip docker commands when docker is unavailable
+                continue
+            assert run(cmd, timeout=120)
+            continue
 
         if cmd.startswith("curl"):
             server = subprocess.Popen(


### PR DESCRIPTION
## Summary
- add Dockerfile and docker-compose.yml
- simplify README to run with Docker
- skip docker commands in README tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fdabef9f4832085b589b8b0c0a665