### PR TITLE
Fix codespace API host

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,10 @@ npm run dev
 ```
 
 and open the shown URL to watch the arena in your browser.
+
+When running inside GitHub Codespaces the API is exposed on a different URL. Set `VITE_API_URL` to the forwarded address before starting the dev server:
+
+```bash
+echo "VITE_API_URL=$(gp url 8000)" > frontend/.env
+npm run dev
+```

--- a/README.md
+++ b/README.md
@@ -61,9 +61,10 @@ curl -X POST -H "Content-Type: application/json" -d '{"bot": "random_bot"}' http
 
 Connect to `ws://localhost:8000/ws` to receive game updates every second.
 
-A basic front‑end built with Vite lives in the `frontend` directory. After installing Node.js dependencies run:
+A basic front‑end built with Vite lives in the `frontend` directory. Install dependencies and start the dev server:
 
 ```bash
+cd frontend
 npm install
 npm run dev
 ```
@@ -73,6 +74,6 @@ and open the shown URL to watch the arena in your browser.
 When running inside GitHub Codespaces the API is exposed on a different URL. Set `VITE_API_URL` to the forwarded address before starting the dev server:
 
 ```bash
-echo "VITE_API_URL=$(gp url 8000)" > frontend/.env
+echo "VITE_API_URL=$(gp url 8000)" > .env
 npm run dev
 ```

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,17 +5,22 @@ export default function App() {
   const [game, setGame] = useState({ bots: {}, board_size: 5, round: 0 })
   const [newBot, setNewBot] = useState('random_bot')
 
+  const apiBase = import.meta.env.VITE_API_URL || ''
+
   useEffect(() => {
-    const ws = new WebSocket('ws://localhost:8000/ws')
+    const wsUrl = apiBase
+      ? apiBase.replace(/^http/, 'ws') + '/ws'
+      : `${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${window.location.host}/ws`
+    const ws = new WebSocket(wsUrl)
     ws.onmessage = (ev) => {
       const data = JSON.parse(ev.data)
       setGame(data)
     }
     return () => ws.close()
-  }, [])
+  }, [apiBase])
 
   const addBot = async () => {
-    await fetch('http://localhost:8000/add_bot', {
+    await fetch(`${apiBase}/add_bot`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ bot: newBot })

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,4 +4,13 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/add_bot': 'http://localhost:8000',
+      '/ws': {
+        target: 'ws://localhost:8000',
+        ws: true,
+      },
+    },
+  },
 })

--- a/webarena.py
+++ b/webarena.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Dict, Tuple, Any, Set
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 
@@ -130,6 +131,12 @@ def load_bot(module_name: str):
 
 
 app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 game = WebGame(board_size=5)
 clients: Set[WebSocket] = set()


### PR DESCRIPTION
## Summary
- add CORS headers to backend
- allow configuring API base via `VITE_API_URL`
- set Vite proxy for `/add_bot` and `/ws`
- document how to run frontend in GitHub Codespaces

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fddb9df348320be8fe154839b6c75