### PR TITLE
Fix frontend API URL and add frontend test

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,8 @@ services:
     volumes:
       - ./frontend:/app
     environment:
-      - VITE_API_URL=http://app:8000
+      # Use localhost so the front-end served to the host browser can reach the backend
+      - VITE_API_URL=http://localhost:8000
     ports:
       - "5173:5173"
     command: sh -c "npm install && npm run dev -- --host"

--- a/tests/test_frontend_page.py
+++ b/tests/test_frontend_page.py
@@ -1,0 +1,50 @@
+import os
+import shutil
+import subprocess
+import time
+import pytest
+
+
+def is_port_open(port, host='localhost'):
+    import socket
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        return s.connect_ex((host, port)) == 0
+
+
+def wait_port(port, timeout=10):
+    start = time.time()
+    while time.time() - start < timeout:
+        if is_port_open(port):
+            return True
+        time.sleep(0.5)
+    return False
+
+
+@pytest.mark.skipif(shutil.which("npm") is None, reason="npm is required")
+def test_frontend_serves_page(tmp_path):
+    # install dependencies
+    subprocess.run("npm install", shell=True, cwd="frontend", check=True)
+
+    backend = subprocess.Popen(
+        "uvicorn webarena:app --reload", shell=True
+    )
+    try:
+        assert wait_port(8000)
+        env = os.environ.copy()
+        env["VITE_API_URL"] = "http://localhost:8000"
+        frontend = subprocess.Popen(
+            "npm run dev -- --host", shell=True, cwd="frontend", env=env
+        )
+        try:
+            assert wait_port(5173)
+            # fetch page
+            out = subprocess.check_output(
+                "curl -s http://localhost:5173", shell=True
+            ).decode()
+            assert "<div id=\"root\"></div>" in out
+        finally:
+            frontend.terminate()
+            frontend.wait(timeout=5)
+    finally:
+        backend.terminate()
+        backend.wait(timeout=5)


### PR DESCRIPTION
## Summary
- fix `VITE_API_URL` so the browser can reach the backend
- add a regression test ensuring the frontend page is served

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fe3b870a08320a0905ff36200b341