### PR TITLE
Fix websocket support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{name="Unknown"}]
 readme = "README.md"
 dependencies = [
     "fastapi",
-    "uvicorn",
+    "uvicorn[standard]",
 ]
 requires-python = ">=3.10"
 


### PR DESCRIPTION
## Summary
- install `uvicorn[standard]` so FastAPI websocket endpoint works

## Testing
- `SKIP_NESTED=1 make test`

------
https://chatgpt.com/codex/tasks/task_e_683ffa62261483208ff247c5c9455cc8