### PR TITLE
Remove dead bots and increase board size

### DIFF
--- a/backend/arena.py
+++ b/backend/arena.py
@@ -8,7 +8,7 @@ except Exception:
     tk = None
 
 class Game:
-    def __init__(self, bots, board_size=5, use_gui=False):
+    def __init__(self, bots, board_size=20, use_gui=False):
         # store hp and position for each bot
         self.bots = {bot.name: {'bot': bot, 'hp': 10} for bot in bots}
         self.board_size = board_size
@@ -83,6 +83,13 @@ class Game:
                     print(
                         f"{name} shoots {target}. {target} HP: {self.bots[target]['hp']}"
                     )
+                    if self.bots[target]['hp'] <= 0:
+                        del self.bots[target]
+                        del self.positions[target]
+                        if self.use_gui:
+                            label = self.labels.pop(target, None)
+                            if label is not None:
+                                label.destroy()
 
     def run(self):
         round_no = 0
@@ -93,8 +100,9 @@ class Game:
             print(f"Round {round_no}")
             if self.use_gui:
                 self._update_gui()
-            for name, info in list(self.bots.items()):
-                if info['hp'] <= 0:
+            for name in list(self.bots.keys()):
+                info = self.bots.get(name)
+                if not info or info['hp'] <= 0:
                     continue
                 state = {
                     'self_hp': info['hp'],

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import './App.css'
 
 export default function App() {
-  const [game, setGame] = useState({ bots: {}, board_size: 5, round: 0 })
+  const [game, setGame] = useState({ bots: {}, board_size: 20, round: 0 })
   const [newBot, setNewBot] = useState('random_bot')
   const [apiStatus, setApiStatus] = useState('')
 


### PR DESCRIPTION
## Summary
- remove bots from the game once their HP drops to 0
- bump default board size to 20

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6840056f5eec8320958b5bc67e78aa13