### PR TITLE
Add colored bots and move arrows

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -17,6 +17,22 @@
   align-items: center;
   justify-content: center;
   font-size: 0.6rem;
+  position: relative;
+}
+
+.bot {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7rem;
+}
+
+.arrow {
+  font-size: 1rem;
 }
 
 .controls {


### PR DESCRIPTION
## Summary
- represent bots as colored circles on the board
- display an arrow in a bot's previous cell pointing to its current cell

## Testing
- `npm run lint` *(fails: warning only)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_684007bba2648320abc7d03bf6929260