### PR TITLE
Visualize damage in RTS board

### DIFF
--- a/backend/webarena.py
+++ b/backend/webarena.py
@@ -22,6 +22,7 @@ class WebGame:
         self.positions: Dict[str, Tuple[int, int]] = {}
         self.round_no = 0
         self._lock = asyncio.Lock()
+        self.attacks: list[tuple[str, str]] = []
 
     def _distance(self, a: Tuple[int, int], b: Tuple[int, int]) -> int:
         return abs(a[0] - b[0]) + abs(a[1] - b[1])
@@ -79,6 +80,7 @@ class WebGame:
                     <= 3
                 ):
                     self.bots[target].hp -= 1
+                    self.attacks.append((name, target))
                     if self.bots[target].hp <= 0:
                         del self.bots[target]
                         self.positions.pop(target, None)
@@ -86,6 +88,7 @@ class WebGame:
     async def step(self) -> Dict[str, Any]:
         async with self._lock:
             self.round_no += 1
+            self.attacks = []
             names = list(self.bots.keys())
             for name in names:
                 bw = self.bots.get(name)
@@ -119,6 +122,7 @@ class WebGame:
                 if bw.hp > 0
             },
             "board_size": self.board_size,
+            "attacks": self.attacks,
         }
 
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -38,3 +38,11 @@
 .controls {
   margin-top: 1rem;
 }
+
+.bot.damaged {
+  box-shadow: 0 0 5px 2px red;
+}
+
+.bot.attacking {
+  box-shadow: 0 0 5px 2px yellow;
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,6 +13,8 @@ import './App.css'
 export default function App() {
   const [game, setGame] = useState({ bots: {}, board_size: 20, round: 0 })
   const [prevPos, setPrevPos] = useState({})
+  const [damaged, setDamaged] = useState([])
+  const [attacking, setAttacking] = useState([])
   const [newBot, setNewBot] = useState('random_bot')
   const [apiStatus, setApiStatus] = useState('')
 
@@ -30,13 +32,21 @@ export default function App() {
       console.debug('ws message', data)
       setGame(prev => {
         const moved = {}
+        const hurt = []
+        const attackers = data.attacks ? data.attacks.map(a => a[0]) : []
         for (const [name, info] of Object.entries(prev.bots)) {
           const newInfo = data.bots[name]
-          if (newInfo && (info.pos[0] !== newInfo.pos[0] || info.pos[1] !== newInfo.pos[1])) {
+          if (!newInfo) continue
+          if (info.pos[0] !== newInfo.pos[0] || info.pos[1] !== newInfo.pos[1]) {
             moved[name] = info.pos
+          }
+          if (newInfo.hp < info.hp) {
+            hurt.push(name)
           }
         }
         setPrevPos(moved)
+        setDamaged(hurt)
+        setAttacking(attackers)
         return data
       })
     }
@@ -95,7 +105,7 @@ export default function App() {
       cells.push(
         <div key={x + ',' + y} className='cell'>
           {bot ? (
-            <div className='bot' style={{ backgroundColor: getColor(bot[0]) }} title={bot[0]}>{bot[1].hp}</div>
+            <div className={`bot${damaged.includes(bot[0]) ? ' damaged' : ''}${attacking.includes(bot[0]) ? ' attacking' : ''}`} style={{ backgroundColor: getColor(bot[0]) }} title={bot[0]}>{bot[1].hp}</div>
           ) : arrow}
         </div>
       )
@@ -117,3 +127,4 @@ export default function App() {
     </div>
   )
 }
+


### PR DESCRIPTION
## Summary
- highlight bots when they take damage so it's easier to see attacks
- also highlight bots that attacked in the current round
- expose attack events from the backend so the frontend can show them

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68400caec2d483209f757ee965ec4a72